### PR TITLE
Fix: mount Grape API.

### DIFF
--- a/app/racks/grape_app.rb
+++ b/app/racks/grape_app.rb
@@ -14,7 +14,3 @@ class GrapeApp < Grape::API
     { hello: 'world!' }
   end
 end
-
-if __FILE__ == $0
-  Rack::Server.start(app: GrapeApp)
-end

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,16 @@
 # This file is used by Rack-based servers to start the application.
 
 require "jets"
+
+require_relative 'app/racks/grape_app'
+
 Jets.boot
-run Jets.application
+
+instance = Rack::Builder.new do
+  map '/api' do
+    run GrapeApp
+  end
+  run Jets.application
+end.to_app
+
+run instance

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,4 @@ Jets.application.configure do
   # local testing environment you may want to log these messages to 'test.log' file to keep your
   # testing suite output readable.
   # config.logger = Jets::Logger.new($strerr)
-
 end


### PR DESCRIPTION
Rack::Server.start does not seem to be mounting the API in a way that invokes middleware.

Related to https://github.com/ruby-grape/grape/issues/2009